### PR TITLE
feat: API 스키마(명세) 자동 생성 기능 개선

### DIFF
--- a/ares/api/serializers/v1/interview.py
+++ b/ares/api/serializers/v1/interview.py
@@ -1,148 +1,78 @@
 # ares/api/serializers/v1/interview.py
 from __future__ import annotations
 from rest_framework import serializers
-
+from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
 
 # ===== 공통 =====
 class MetaIn(serializers.Serializer):
     company = serializers.CharField(required=False, allow_blank=True, default="")
-    name = serializers.CharField(required=False, allow_blank=True, default="") # Added
+    name = serializers.CharField(required=False, allow_blank=True, default="")
     division = serializers.CharField(required=False, allow_blank=True, default="")
     role = serializers.CharField(required=False, allow_blank=True, default="")
-    job_title = serializers.CharField(required=False, allow_blank=True, default="") # Added
+    job_title = serializers.CharField(required=False, allow_blank=True, default="")
     skills = serializers.ListField(child=serializers.CharField(), required=False, default=list)
     jd_kpis = serializers.ListField(child=serializers.CharField(), required=False, default=list)
 
-
-# ===== 내부 유틸: 난이도/언어 정규화 =====
-_DIFFICULTY_MAP = {
-    "쉬움": "easy",
-    "보통": "normal",
-    "어려움": "hard",
-    "medium": "normal",  # 혼동 방지용
-}
-def _norm_difficulty(v: str) -> str:
-    v = (v or "normal").strip().lower()
-    return _DIFFICULTY_MAP.get(v, v)
-
-def _norm_language(v: str) -> str:
-    v = (v or "ko").strip().lower()
-    return "en" if v == "en" else "ko"
-
-
 # ===== Start =====
 class InterviewStartIn(serializers.Serializer):
-    # ✅ 필수 + 빈문자열 불가(요구사항 유지)
     jd_context = serializers.CharField(required=True, allow_blank=False, trim_whitespace=True)
     resume_context = serializers.CharField(required=True, allow_blank=False, trim_whitespace=True)
-
-    # 선택
     research_context = serializers.CharField(required=False, allow_blank=True, default="")
-    research_bias = serializers.BooleanField(required=False, default=True)
-    mode = serializers.ChoiceField(
-        choices=["온디맨드", "프리플랜", "혼합형(추천)"],
-        required=False,
-        default="혼합형(추천)",
-    )
-
-    difficulty = serializers.ChoiceField(
-        choices=["easy", "normal", "hard", "medium", "쉬움", "보통", "어려움"],
-        required=False,
-        default="normal",
-    )
+    difficulty = serializers.ChoiceField(choices=["easy", "normal", "hard"], required=False, default="normal")
     language = serializers.ChoiceField(choices=["ko", "en"], required=False, default="ko")
-
+    interviewer_mode = serializers.ChoiceField(choices=["team_lead", "executive"], required=False, default="team_lead")
     meta = MetaIn(required=False, default=dict)
     ncs_context = serializers.JSONField(required=False, default=dict)
-    ncs_query = serializers.CharField(required=False, allow_blank=True, default="")
-
-    # ---- 방어적 검증(길이/트림/정규화) ----
-    def validate_jd_context(self, v: str) -> str:
-        v = (v or "").strip()
-        if len(v) < 20:
-            raise serializers.ValidationError("JD 텍스트는 최소 20자 이상 입력하세요.")
-        return v
-
-    def validate_resume_context(self, v: str) -> str:
-        v = (v or "").strip()
-        if len(v) < 20:
-            raise serializers.ValidationError("이력서/경험 요약은 최소 20자 이상 입력하세요.")
-        return v
-
-    def validate_difficulty(self, v: str) -> str:
-        return _norm_difficulty(v)
-
-    def validate_language(self, v: str) -> str:
-        return _norm_language(v)
-
 
 class InterviewStartOut(serializers.Serializer):
     message = serializers.CharField()
     question = serializers.CharField()
     session_id = serializers.UUIDField()
     turn_index = serializers.IntegerField()
-    # NCS 컨텍스트 포함 (뷰에서 session.context 반환)
     context = serializers.JSONField(required=False)
-    # 🔹 프런트 동기화를 위해 노출(뷰에서 이미 세션에 저장함)
     language = serializers.CharField(required=False, default="ko")
     difficulty = serializers.CharField(required=False, default="normal")
+    interviewer_mode = serializers.CharField(required=False, default="team_lead")
 
-
-# ===== Next (세션 기반 + 구버전 호환) =====
+# ===== Next =====
 class InterviewNextIn(serializers.Serializer):
-    # 세션 기반 권장
-    session_id = serializers.UUIDField(required=False)
+    session_id = serializers.UUIDField(required=True)
 
-    # 구버전 호환 필드
-    context = serializers.CharField(required=False, allow_blank=True, default="")
-    prev_questions = serializers.ListField(child=serializers.CharField(), required=False, default=list)
-
-    # 한/영 난이도 + language
-    difficulty = serializers.ChoiceField(
-        choices=["easy", "normal", "hard", "medium", "쉬움", "보통", "어려움"],
-        required=False,
-        default="normal",
-    )
-    language = serializers.ChoiceField(choices=["ko", "en"], required=False, default="ko")
-
-    meta = serializers.DictField(required=False, default=dict)
-    ncs_query = serializers.CharField(required=False, allow_blank=True, default="")
-
-    def validate_difficulty(self, v: str) -> str:
-        return _norm_difficulty(v)
-
-    def validate_language(self, v: str) -> str:
-        return _norm_language(v)
-
-
+@extend_schema_serializer(
+    examples=[
+        OpenApiExample(
+            'Next Question',
+            value={
+                "session_id": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+                "turn_index": 2,
+                "question": "Tell me about a time you handled a difficult stakeholder.",
+                "done": False,
+            },
+            response_only=True,
+        ),
+        OpenApiExample(
+            'Interview Finished',
+            value={
+                "session_id": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+                "turn_index": None,
+                "question": None,
+                "done": True,
+            },
+            response_only=True,
+        ),
+    ]
+)
 class InterviewNextOut(serializers.Serializer):
-    # 변경: 메인질문이 아닌 꼬리질문 세트 반환
-    followups = serializers.ListField(child=serializers.CharField())
-    session_id = serializers.UUIDField(required=False)
-    turn_index = serializers.IntegerField(required=False)
-
+    session_id = serializers.UUIDField()
+    turn_index = serializers.IntegerField(allow_null=True)
+    question = serializers.CharField(allow_null=True)
+    done = serializers.BooleanField()
 
 # ===== Answer =====
 class InterviewAnswerIn(serializers.Serializer):
-    # 세션 기반
-    session_id = serializers.UUIDField(required=False)
-    turn_index = serializers.IntegerField(required=False)  # 직전 interviewer 질문 index
-
-    # 구버전 호환 필드
-    context = serializers.CharField(required=False, allow_blank=True, default="")
-    meta = serializers.DictField(required=False, default=dict)
-
-    # 공통
-    question = serializers.CharField(required=False, allow_blank=True, default="")
+    session_id = serializers.UUIDField(required=True)
+    question = serializers.CharField(required=True)
     answer = serializers.CharField(required=True, allow_blank=False, trim_whitespace=True)
-
-    # 언어/난이도
-    language = serializers.ChoiceField(choices=["ko", "en"], required=False, default="ko")
-    difficulty = serializers.ChoiceField(
-        choices=["easy", "normal", "hard", "medium", "쉬움", "보통", "어려움"],
-        required=False,
-        default="normal",
-    )
 
     def validate_answer(self, v: str) -> str:
         v = (v or "").strip()
@@ -150,41 +80,40 @@ class InterviewAnswerIn(serializers.Serializer):
             raise serializers.ValidationError("답변은 최소 5자 이상 입력하세요.")
         return v
 
-    def validate_difficulty(self, v: str) -> str:
-        return _norm_difficulty(v)
-
-    def validate_language(self, v: str) -> str:
-        return _norm_language(v)
-
+class InterviewAnswerAnalysis(serializers.Serializer):
+    structured = serializers.DictField()
+    rag_analysis = serializers.DictField()
 
 class InterviewAnswerOut(serializers.Serializer):
-    ok = serializers.BooleanField(default=True)
-    session_id = serializers.UUIDField()
-    turn_index = serializers.IntegerField()
-    
-    # Analysis results from the new bot
-    selected_framework_answerer = serializers.ListField(child=serializers.CharField(), required=False)
-    star_analysis = serializers.DictField(required=False, allow_null=True)
-    base_analysis = serializers.DictField(required=False, allow_null=True)
-    case_analysis = serializers.DictField(required=False, allow_null=True)
-    system_analysis = serializers.DictField(required=False, allow_null=True)
-    scores = serializers.DictField(required=False, allow_null=True)
-    scoring_reason = serializers.CharField(required=False, allow_blank=True, allow_null=True)
-    strengths = serializers.ListField(child=serializers.CharField(), required=False)
-    improvements = serializers.ListField(child=serializers.CharField(), required=False)
-    feedback = serializers.CharField(required=False, allow_blank=True, allow_null=True)
-    model_answer = serializers.CharField(required=False, allow_blank=True, allow_null=True)
-    model_answer_framework = serializers.CharField(required=False, allow_blank=True, allow_null=True)
-
+    analysis = InterviewAnswerAnalysis()
+    followups_buffered = serializers.ListField(child=serializers.CharField())
+    message = serializers.CharField()
 
 # ===== Finish =====
 class InterviewFinishIn(serializers.Serializer):
-    session_id = serializers.UUIDField(required=False)  # 세션 기반 권장
-    # 구버전 호환
-    context = serializers.CharField(required=False, allow_blank=True, default="")
-    meta = serializers.DictField(required=False, default=dict)
-
+    session_id = serializers.UUIDField(required=True)
 
 class InterviewFinishOut(serializers.Serializer):
     report_id = serializers.CharField()
     status = serializers.CharField()
+
+# ===== Report =====
+class InterviewReportOut(serializers.Serializer):
+    overall_summary = serializers.CharField()
+    interview_flow_rationale = serializers.CharField()
+    strengths_matrix = serializers.ListField(child=serializers.DictField())
+    weaknesses_matrix = serializers.ListField(child=serializers.DictField())
+    score_aggregation = serializers.DictField()
+    missed_opportunities = serializers.ListField(child=serializers.CharField())
+    potential_followups_global = serializers.ListField(child=serializers.CharField())
+    resume_feedback = serializers.DictField()
+    hiring_recommendation = serializers.ChoiceField(choices=["strong_hire", "hire", "no_hire"])
+    next_actions = serializers.ListField(child=serializers.CharField())
+    question_by_question_feedback = serializers.ListField(child=serializers.DictField())
+
+# ===== Find Companies =====
+class FindCompaniesRequestSerializer(serializers.Serializer):
+    keyword = serializers.CharField()
+
+class FindCompaniesResponseSerializer(serializers.Serializer):
+    companies = serializers.ListField(child=serializers.CharField())

--- a/ares/api/serializers/v1/resume_analysis.py
+++ b/ares/api/serializers/v1/resume_analysis.py
@@ -1,5 +1,6 @@
 # ares/api/serializers/v1/resume_analysis.py
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
 
 
 class CompanyDataSerializer(serializers.Serializer):
@@ -21,3 +22,48 @@ class ResumeAnalysisInSerializer(serializers.Serializer):
     research_text = serializers.CharField(required=False, allow_blank=True)
 
     company = serializers.CharField() # JSON string
+
+
+@extend_schema_serializer(
+    examples=[
+        OpenApiExample(
+            'Success Response',
+            value={
+                "overall_score": 88.5,
+                "fit_analysis": {
+                    "summary": "Candidate seems to be a good fit for the role.",
+                    "details": "..."
+                },
+                "strength_analysis": {
+                    "summary": "Strong background in Python and Django.",
+                    "details": "..."
+                },
+                "weakness_analysis": {
+                    "summary": "Limited experience with cloud infrastructure.",
+                    "details": "..."
+                },
+                "ncs_context": {
+                    "ncs_query": "...",
+                    "ncs": []
+                },
+                "input_contexts": {
+                    "refined": {
+                        "jd_context": "...",
+                        "resume_context": "...",
+                        "research_context": "...",
+                        "meta": {},
+                        "ncs_context": {}
+                    }
+                }
+            },
+            response_only=True,
+        )
+    ]
+)
+class ResumeAnalysisOutSerializer(serializers.Serializer):
+    overall_score = serializers.FloatField(required=False)
+    fit_analysis = serializers.DictField(required=False)
+    strength_analysis = serializers.DictField(required=False)
+    weakness_analysis = serializers.DictField(required=False)
+    ncs_context = serializers.DictField(required=False)
+    input_contexts = serializers.DictField(required=False)

--- a/ares/api/views/v1/analyze.py
+++ b/ares/api/views/v1/analyze.py
@@ -1,7 +1,7 @@
 # ares/api/views/v1/analyze.py
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework import status
+from rest_framework import status, permissions
 from django.conf import settings
 import pandas as pd
 import numpy as np
@@ -9,12 +9,28 @@ import os
 import random
 from pathlib import Path
 from django.http import JsonResponse
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
 
 # New import for the percentile service
 from ares.api.services.percentile_service import percentile_service
 # New import for the AI advisor service
 from ares.api.services.openai_advisor import advisor as ai_advisor
 
+# --- Serializers for drf-spectacular ---
+class AdviceRequestSerializer(serializers.Serializer):
+    analysis_data = serializers.JSONField()
+
+class AdviceResponseSerializer(serializers.Serializer):
+    advice = serializers.CharField()
+
+class PercentileResponseSerializer(serializers.Serializer):
+    percentiles = serializers.DictField(child=serializers.FloatField())
+
+class AnalyzeResponseSerializer(serializers.Serializer):
+    results = serializers.DictField()
+
+# ----------------------------------------
 
 class GenerateAIAdviceView(APIView):
     """
@@ -23,6 +39,11 @@ class GenerateAIAdviceView(APIView):
     authentication_classes = []
     permission_classes = []
 
+    @extend_schema(
+        summary="Generate AI-based Advice",
+        request=AdviceRequestSerializer,
+        responses=AdviceResponseSerializer
+    )
     def post(self, request):
         """
         Generates advice based on the provided analysis data.
@@ -52,6 +73,11 @@ class PercentileAnalysisView(APIView):
     authentication_classes = []
     permission_classes = []
 
+    @extend_schema(
+        summary="Calculate Percentiles",
+        description="Calculates percentiles for given scores based on query parameters.",
+        responses=PercentileResponseSerializer
+    )
     def get(self, request):
         """
         Calculates percentiles for given scores based on query parameters.
@@ -204,6 +230,11 @@ class AnalyzeView(APIView):
     authentication_classes = []
     permission_classes = []
 
+    @extend_schema(
+        summary="Perform Score Analysis (Dummy Data)",
+        description="Performs a score analysis using dummy data.",
+        responses=AnalyzeResponseSerializer
+    )
     def get(self, request):
         """점수 분석 수행"""
         try:

--- a/ares/api/views/v1/example.py
+++ b/ares/api/views/v1/example.py
@@ -2,6 +2,7 @@ import datetime
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 from ares.api.serializers.v1.example import ExampleSerializer
+from drf_spectacular.utils import extend_schema
 
 
 # Dummy data
@@ -26,11 +27,13 @@ class ExampleViewSet(viewsets.ViewSet):
     A simple ViewSet for viewing examples with dummy data.
     """
 
+    @extend_schema(responses=ExampleSerializer(many=True))
     def list(self, _):
         serializer = ExampleSerializer(DUMMY_DATA, many=True)
         return Response(serializer.data)
 
-    def retrieve(self, _, pk=None):
+    @extend_schema(responses=ExampleSerializer)
+    def retrieve(self, _, pk: int = None):
         try:
             item = next(item for item in DUMMY_DATA if item["id"] == int(pk))
         except (StopIteration, ValueError):

--- a/ares/api/views/v1/resume_analysis.py
+++ b/ares/api/views/v1/resume_analysis.py
@@ -4,9 +4,14 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status, permissions
 from rest_framework.parsers import MultiPartParser, JSONParser
+from drf_spectacular.utils import extend_schema
 
 # Serializers
-from ares.api.serializers.v1.resume_analysis import ResumeAnalysisInSerializer, CompanyDataSerializer
+from ares.api.serializers.v1.resume_analysis import (
+    ResumeAnalysisInSerializer,
+    CompanyDataSerializer,
+    ResumeAnalysisOutSerializer,
+)
 
 # Services
 from ares.api.services import ocr_service, resume_service
@@ -151,6 +156,16 @@ class ResumeAnalysisAPIView(APIView):
             print(f"[warn] LLM refinement failed for {context_type}: {e}. Returning raw text.")
             return raw_text
 
+    @extend_schema(
+        summary="Analyze Resume against Job Description",
+        description="""
+Takes a resume, a job description (JD), and optional company research material.
+It performs a detailed analysis of the resume's fit for the job, providing scores and feedback.
+The input can be either text or file uploads.
+""",
+        request=ResumeAnalysisInSerializer,
+        responses=ResumeAnalysisOutSerializer
+    )
     def post(self, request, *args, **kwargs):
         serializer = ResumeAnalysisInSerializer(data=request.data)
         if not serializer.is_valid():

--- a/ares/urls.py
+++ b/ares/urls.py
@@ -32,4 +32,9 @@ urlpatterns = [
     # [4단계를 위한 URL 패턴들]
     path('calendar/', views.calendar_view, name='calendar'),
     path('add_event/', views.add_event, name='add_event'),
+    
+    # DRF Spectacular URLs
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
+    path("api/schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
 ]

--- a/ares/views.py
+++ b/ares/views.py
@@ -13,9 +13,18 @@ from google_auth_oauthlib.flow import Flow
 from googleapiclient.discovery import build
 
 
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
+
+
+class HealthCheckSerializer(serializers.Serializer):
+    status = serializers.CharField()
+
+
 class HealthCheckView(APIView):
     """API server health check"""
 
+    @extend_schema(responses=HealthCheckSerializer)
     def get(self, request, *args, **kwargs):
         return Response({"status": "ok"}, status=status.HTTP_200_OK)
 

--- a/schema.yaml
+++ b/schema.yaml
@@ -8,35 +8,56 @@ paths:
     post:
       operationId: api_v1_analysis_advice_create
       description: Generates advice based on the provided analysis data.
+      summary: Generate AI-based Advice
       tags:
       - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdviceRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AdviceRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AdviceRequest'
+        required: true
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdviceResponse'
+          description: ''
   /api/v1/analysis/percentiles/:
     get:
       operationId: api_v1_analysis_percentiles_retrieve
-      description: |-
-        Calculates percentiles for given scores based on query parameters.
-
-        Query Params:
-        - Scores (required): e.g., confidence_score=85, fluency_score=92
-        - Filters (optional): e.g., gender=MALE, ageRange=-34, occupation=ICT
-          (Filters can have multiple values, e.g., &occupation=ICT&occupation=RND)
+      description: Calculates percentiles for given scores based on query parameters.
+      summary: Calculate Percentiles
       tags:
       - api
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PercentileResponse'
+          description: ''
   /api/v1/analyze/:
     get:
       operationId: api_v1_analyze_retrieve
-      description: 점수 분석 수행
+      description: Performs a score analysis using dummy data.
+      summary: Perform Score Analysis (Dummy Data)
       tags:
       - api
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalyzeResponse'
+          description: ''
   /api/v1/auth/google/:
     post:
       operationId: api_v1_auth_google_create
@@ -463,7 +484,7 @@ paths:
           description: No response body
   /api/v1/examples/:
     get:
-      operationId: api_v1_examples_retrieve
+      operationId: api_v1_examples_list
       description: A simple ViewSet for viewing examples with dummy data.
       tags:
       - api
@@ -472,10 +493,16 @@ paths:
       - jwtCookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Example'
+          description: ''
   /api/v1/examples/{id}/:
     get:
-      operationId: api_v1_examples_retrieve_2
+      operationId: api_v1_examples_retrieve
       description: A simple ViewSet for viewing examples with dummy data.
       parameters:
       - in: path
@@ -490,68 +517,148 @@ paths:
       - jwtCookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Example'
+          description: ''
   /api/v1/interview/find-companies/:
     post:
       operationId: api_v1_interview_find_companies_create
       description: 키워드로 계열사 목록을 검색하는 API
+      summary: Find Affiliate Companies
       tags:
       - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FindCompaniesRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/FindCompaniesRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FindCompaniesRequest'
+        required: true
       security:
       - jwtHeaderAuth: []
       - jwtCookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindCompaniesResponse'
+          description: ''
   /api/v1/interviews/answer/:
     post:
       operationId: api_v1_interviews_answer_create
-      description: |-
-        - 후보자 답변을 저장
-        - 분석 수행 (구조화 + RAG)
-        - follow-up 후보 리스트 생성 후 세션 FSM에 '적재만' (커서 이동 없음)
+      description: Submits a candidate's answer to a question, triggers analysis,
+        and buffers potential follow-up questions.
+      summary: Submit an Answer
       tags:
       - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InterviewAnswerIn'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/InterviewAnswerIn'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/InterviewAnswerIn'
+        required: true
       security:
       - {}
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterviewAnswerOut'
+          description: ''
   /api/v1/interviews/finish/:
     post:
       operationId: api_v1_interviews_finish_create
-      description: |-
-        - 세션 종료 처리
-        - 리포트 즉시 생성 → 세션 meta["final_report"]에 저장, report_id/finished_at 세팅
+      description: Ends the session, generates the final report, and stores it.
+      summary: Finish an Interview Session
       tags:
       - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InterviewFinishIn'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/InterviewFinishIn'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/InterviewFinishIn'
+        required: true
       security:
       - {}
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterviewFinishOut'
+          description: ''
   /api/v1/interviews/next/:
     post:
       operationId: api_v1_interviews_next_create
-      description: |-
-        - FSM에 기반해 다음 질문을 결정
-          1) pending_followups가 남아있고 followup_idx < 상한 → 해당 꼬리질문 반환
-          2) 아니면 메인 플랜 다음 문항으로 커서 이동하여 질문 반환
-          3) 전부 소진되면 done:true
+      description: Based on the interview's state machine (FSM), determines and returns
+        the next question. This could be a follow-up or the next main question from
+        the plan.
+      summary: Get Next Question
       tags:
       - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InterviewNextIn'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/InterviewNextIn'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/InterviewNextIn'
+        required: true
       security:
       - {}
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterviewNextOut'
+              examples:
+                NextQuestion:
+                  value:
+                    session_id: a1b2c3d4-e5f6-7890-1234-567890abcdef
+                    turn_index: 2
+                    question: Tell me about a time you handled a difficult stakeholder.
+                    done: false
+                  summary: Next Question
+                InterviewFinished:
+                  value:
+                    session_id: a1b2c3d4-e5f6-7890-1234-567890abcdef
+                    turn_index: null
+                    question: null
+                    done: true
+                  summary: Interview Finished
+          description: ''
   /api/v1/interviews/report/{session_id}/:
     get:
       operationId: api_v1_interviews_report_retrieve
-      description: |-
-        - 세션별 리포트 반환
-        - 이미 meta["final_report"]가 있으면 그것을 반환
-        - 없으면 온디맨드 생성 후 저장
+      description: Retrieves the final report for a given session ID. If the report
+        is not already generated, it will be created on-demand.
+      summary: Get Interview Report
       parameters:
       - in: path
         name: session_id
@@ -565,17 +672,40 @@ paths:
       - {}
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterviewReportOut'
+          description: ''
   /api/v1/interviews/start/:
     post:
       operationId: api_v1_interviews_start_create
+      description: Creates a new interview session based on the provided context and
+        returns the first question.
+      summary: Start a New Interview Session
       tags:
       - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InterviewStartIn'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/InterviewStartIn'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/InterviewStartIn'
+        required: true
       security:
       - {}
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterviewStartOut'
+          description: ''
   /api/v1/profile/careers/:
     get:
       operationId: api_v1_profile_careers_list
@@ -1437,15 +1567,58 @@ paths:
   /api/v1/resume/analyze/:
     post:
       operationId: api_v1_resume_analyze_create
+      description: |2
+
+        Takes a resume, a job description (JD), and optional company research material.
+        It performs a detailed analysis of the resume's fit for the job, providing scores and feedback.
+        The input can be either text or file uploads.
+      summary: Analyze Resume against Job Description
       tags:
       - api
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ResumeAnalysisIn'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResumeAnalysisIn'
+        required: true
       security:
       - jwtHeaderAuth: []
       - jwtCookieAuth: []
       - {}
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResumeAnalysisOut'
+              examples:
+                SuccessResponse:
+                  value:
+                    overall_score: 88.5
+                    fit_analysis:
+                      summary: Candidate seems to be a good fit for the role.
+                      details: '...'
+                    strength_analysis:
+                      summary: Strong background in Python and Django.
+                      details: '...'
+                    weakness_analysis:
+                      summary: Limited experience with cloud infrastructure.
+                      details: '...'
+                    ncs_context:
+                      ncs_query: '...'
+                      ncs: []
+                    input_contexts:
+                      refined:
+                        jd_context: '...'
+                        resume_context: '...'
+                        research_context: '...'
+                        meta: {}
+                        ncs_context: {}
+                  summary: Success Response
+          description: ''
   /api/v1/resumes/:
     get:
       operationId: api_v1_resumes_list
@@ -2604,9 +2777,34 @@ paths:
       - jwtCookieAuth: []
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthCheck'
+          description: ''
 components:
   schemas:
+    AdviceRequest:
+      type: object
+      properties:
+        analysis_data: {}
+      required:
+      - analysis_data
+    AdviceResponse:
+      type: object
+      properties:
+        advice:
+          type: string
+      required:
+      - advice
+    AnalyzeResponse:
+      type: object
+      properties:
+        results:
+          type: object
+          additionalProperties: {}
+      required:
+      - results
     BlankEnum:
       enum:
       - ''
@@ -2702,6 +2900,16 @@ components:
         * `bachelor` - 학사
         * `master` - 석사
         * `doctorate` - 박사
+    DifficultyEnum:
+      enum:
+      - easy
+      - normal
+      - hard
+      type: string
+      description: |-
+        * `easy` - easy
+        * `normal` - normal
+        * `hard` - hard
     Disability:
       type: object
       properties:
@@ -2779,6 +2987,25 @@ components:
       - school_type
       - status
       - user
+    Example:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+      required:
+      - created_at
+      - description
+      - id
+      - name
     ExperienceTypeEnum:
       enum:
       - newcomer
@@ -2787,6 +3014,22 @@ components:
       description: |-
         * `newcomer` - 신입
         * `experienced` - 경력
+    FindCompaniesRequest:
+      type: object
+      properties:
+        keyword:
+          type: string
+      required:
+      - keyword
+    FindCompaniesResponse:
+      type: object
+      properties:
+        companies:
+          type: array
+          items:
+            type: string
+      required:
+      - companies
     GenderEnum:
       enum:
       - male
@@ -2795,6 +3038,226 @@ components:
       description: |-
         * `male` - Male
         * `female` - Female
+    HealthCheck:
+      type: object
+      properties:
+        status:
+          type: string
+      required:
+      - status
+    HiringRecommendationEnum:
+      enum:
+      - strong_hire
+      - hire
+      - no_hire
+      type: string
+      description: |-
+        * `strong_hire` - strong_hire
+        * `hire` - hire
+        * `no_hire` - no_hire
+    InterviewAnswerAnalysis:
+      type: object
+      properties:
+        structured:
+          type: object
+          additionalProperties: {}
+        rag_analysis:
+          type: object
+          additionalProperties: {}
+      required:
+      - rag_analysis
+      - structured
+    InterviewAnswerIn:
+      type: object
+      properties:
+        session_id:
+          type: string
+          format: uuid
+        question:
+          type: string
+        answer:
+          type: string
+      required:
+      - answer
+      - question
+      - session_id
+    InterviewAnswerOut:
+      type: object
+      properties:
+        analysis:
+          $ref: '#/components/schemas/InterviewAnswerAnalysis'
+        followups_buffered:
+          type: array
+          items:
+            type: string
+        message:
+          type: string
+      required:
+      - analysis
+      - followups_buffered
+      - message
+    InterviewFinishIn:
+      type: object
+      properties:
+        session_id:
+          type: string
+          format: uuid
+      required:
+      - session_id
+    InterviewFinishOut:
+      type: object
+      properties:
+        report_id:
+          type: string
+        status:
+          type: string
+      required:
+      - report_id
+      - status
+    InterviewNextIn:
+      type: object
+      properties:
+        session_id:
+          type: string
+          format: uuid
+      required:
+      - session_id
+    InterviewNextOut:
+      type: object
+      properties:
+        session_id:
+          type: string
+          format: uuid
+        turn_index:
+          type: integer
+          nullable: true
+        question:
+          type: string
+          nullable: true
+        done:
+          type: boolean
+      required:
+      - done
+      - question
+      - session_id
+      - turn_index
+    InterviewReportOut:
+      type: object
+      properties:
+        overall_summary:
+          type: string
+        interview_flow_rationale:
+          type: string
+        strengths_matrix:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+        weaknesses_matrix:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+        score_aggregation:
+          type: object
+          additionalProperties: {}
+        missed_opportunities:
+          type: array
+          items:
+            type: string
+        potential_followups_global:
+          type: array
+          items:
+            type: string
+        resume_feedback:
+          type: object
+          additionalProperties: {}
+        hiring_recommendation:
+          $ref: '#/components/schemas/HiringRecommendationEnum'
+        next_actions:
+          type: array
+          items:
+            type: string
+        question_by_question_feedback:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+      - hiring_recommendation
+      - interview_flow_rationale
+      - missed_opportunities
+      - next_actions
+      - overall_summary
+      - potential_followups_global
+      - question_by_question_feedback
+      - resume_feedback
+      - score_aggregation
+      - strengths_matrix
+      - weaknesses_matrix
+    InterviewStartIn:
+      type: object
+      properties:
+        jd_context:
+          type: string
+        resume_context:
+          type: string
+        research_context:
+          type: string
+          default: ''
+        difficulty:
+          allOf:
+          - $ref: '#/components/schemas/DifficultyEnum'
+          default: normal
+        language:
+          allOf:
+          - $ref: '#/components/schemas/LanguageEnum'
+          default: ko
+        interviewer_mode:
+          allOf:
+          - $ref: '#/components/schemas/InterviewerModeEnum'
+          default: team_lead
+        meta:
+          $ref: '#/components/schemas/MetaIn'
+        ncs_context: {}
+      required:
+      - jd_context
+      - resume_context
+    InterviewStartOut:
+      type: object
+      properties:
+        message:
+          type: string
+        question:
+          type: string
+        session_id:
+          type: string
+          format: uuid
+        turn_index:
+          type: integer
+        context: {}
+        language:
+          type: string
+          default: ko
+        difficulty:
+          type: string
+          default: normal
+        interviewer_mode:
+          type: string
+          default: team_lead
+      required:
+      - message
+      - question
+      - session_id
+      - turn_index
+    InterviewerModeEnum:
+      enum:
+      - team_lead
+      - executive
+      type: string
+      description: |-
+        * `team_lead` - team_lead
+        * `executive` - executive
     JWT:
       type: object
       description: Serializer for JWT authentication.
@@ -2829,6 +3292,14 @@ components:
       - id
       - job_title
       - user
+    LanguageEnum:
+      enum:
+      - ko
+      - en
+      type: string
+      description: |-
+        * `ko` - ko
+        * `en` - en
     Login:
       type: object
       properties:
@@ -2841,6 +3312,32 @@ components:
           type: string
       required:
       - password
+    MetaIn:
+      type: object
+      properties:
+        company:
+          type: string
+          default: ''
+        name:
+          type: string
+          default: ''
+        division:
+          type: string
+          default: ''
+        role:
+          type: string
+          default: ''
+        job_title:
+          type: string
+          default: ''
+        skills:
+          type: array
+          items:
+            type: string
+        jd_kpis:
+          type: array
+          items:
+            type: string
     MilitaryService:
       type: object
       properties:
@@ -3274,6 +3771,16 @@ components:
       - id
       - patriot_code
       - user
+    PercentileResponse:
+      type: object
+      properties:
+        percentiles:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+      required:
+      - percentiles
     RestAuthDetail:
       type: object
       properties:
@@ -3312,6 +3819,52 @@ components:
       - title
       - updated_at
       - user
+    ResumeAnalysisIn:
+      type: object
+      properties:
+        jd_file:
+          type: string
+          format: uri
+          nullable: true
+        resume_file:
+          type: string
+          format: uri
+          nullable: true
+        research_file:
+          type: string
+          format: uri
+          nullable: true
+        jd_text:
+          type: string
+        resume_text:
+          type: string
+        research_text:
+          type: string
+        company:
+          type: string
+      required:
+      - company
+    ResumeAnalysisOut:
+      type: object
+      properties:
+        overall_score:
+          type: number
+          format: double
+        fit_analysis:
+          type: object
+          additionalProperties: {}
+        strength_analysis:
+          type: object
+          additionalProperties: {}
+        weakness_analysis:
+          type: object
+          additionalProperties: {}
+        ncs_context:
+          type: object
+          additionalProperties: {}
+        input_contexts:
+          type: object
+          additionalProperties: {}
     ResumeAward:
       type: object
       properties:


### PR DESCRIPTION
## 개요

drf-spectacular을 적용하여 API 명세(schema.yaml)가 소스 코드로부터 자동으로 생성되도록 개선했습니다. 이를 통해 API 문서의 신뢰성과 유지보수성이 향상되었습니다.

## 배경

기존에는 Serializer/Response 지정이 불완전하여 Swagger UI에 일부 API가 누락되거나 “serializer를 추측할 수 없음” 오류가 발생했습니다. 또한 불필요한 필드나 중복된 import로 인해 코드 가독성과 문서 생성 정확성이 떨어졌습니다.

## 변경 사항

* **Serializer 개선**

  * `interview`, `resume_analysis` 등 주요 API의 실제 로직에 맞춰 응답(Response) Serializer를 구현
  * `InterviewStartIn` Serializer에 `interviewer_mode` 필드 추가 (면접관 모드 설정 지원)
  * 사용하지 않는 필드 제거로 Request Serializer 단순화

* **API View 데코레이터 적용**

  * `@extend_schema`를 `interview`, `resume_analysis` 등 주요 API View에 적용
  * API 명세 자동 생성 시 응답 Serializer가 정확히 반영되도록 보완

* **Swagger UI / ReDoc 활성화**

  * `ares/urls.py`에 Swagger UI 및 ReDoc 페이지 경로 추가
  * 브라우저에서 자동 생성된 API 문서를 확인 가능

* **버그 수정**

  * `interview.py`의 중복된 `__future__ import` 제거 (SyntaxError 방지)
  * `FindCompaniesView`의 데코레이터 적용 오류 수정

## 스크린샷 / 동영상 (선택)

(필요 시 Swagger UI / ReDoc 동작 화면 캡처 첨부)

## 관련 이슈

* \#이슈번호

## 관련 문서 (선택)

* API 명세 자동화 관련 설계 문서 또는 다이어그램 링크

## 추가 사항 (선택)

* PR 머지 후, 기존 수동 작성된 API 문서와의 중복 여부 점검 필요